### PR TITLE
Fix the risk of expanding xml external entities in FOAF data.

### DIFF
--- a/lib/XML/FOAF.pm
+++ b/lib/XML/FOAF.pm
@@ -50,6 +50,12 @@ sub new {
         $foaf->{raw_data} = $stream;
         %pair = ( Source => $stream, SourceType => 'file' );
     }
+    ## Turn off expanding external entities in XML::Parser to avoid
+    ## security risk reading local file due to usage of XML::Parser
+    ## in RDF::Core::Parser.
+    local $XML::Parser::Expat::Handler_Setters{ExternEnt}    = sub {};
+    local $XML::Parser::Expat::Handler_Setters{ExternEntFin} = sub {};
+
     my $parser = RDF::Core::Model::Parser->new(
                        Model => $foaf->{model},
                        BaseURI => $base_uri,

--- a/t/04-external-entity.t
+++ b/t/04-external-entity.t
@@ -1,0 +1,22 @@
+use strict;
+
+use Test::More tests => 2;
+use XML::FOAF;
+
+my $rdf = <<'FOAF';
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE foo [
+  <!ENTITY ref SYSTEM "file:///etc/passwd">
+]>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:foaf="http://xmlns.com/foaf/0.1/">
+<foaf:Person>
+<foaf:name>/etc/passwd:&ref;eof</foaf:name>
+</foaf:Person>
+</rdf:RDF>
+FOAF
+
+my $foaf = XML::FOAF->new(\$rdf);
+is(ref $foaf, 'XML::FOAF');
+is($foaf->person->name, '/etc/passwd:eof');


### PR DESCRIPTION
Turn off expanding external entities in XML::Parser to avoid security risk.
