### PR TITLE
Require HTML::Parser and LWP::UserAgent in Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,6 +3,8 @@ name 'XML-FOAF';
 all_from 'lib/XML/FOAF.pm';
 readme_from 'lib/XML/FOAF.pm';
 
+requires 'HTML::Parser';
+requires 'LWP::UserAgent';
 requires 'RDF::Core';
 requires 'URI';
 


### PR DESCRIPTION
[rt#75490](https://rt.cpan.org/Public/Bug/Display.html?id=75490) lists two missing dependencies from a failing CPANTesters report: HTML::Parser and LWP::UserAgent. This patch updates Makefile.PL to contain a requires statement for each of these
