### PR TITLE
Enable warnings by default.

### DIFF
--- a/lib/XML/FOAF/ErrorHandler.pm
+++ b/lib/XML/FOAF/ErrorHandler.pm
@@ -1,5 +1,6 @@
 package XML::FOAF::ErrorHandler;
 use strict;
+use warnings;
 
 use vars qw( $ERROR );
 

--- a/lib/XML/FOAF/Person.pm
+++ b/lib/XML/FOAF/Person.pm
@@ -1,5 +1,6 @@
 package XML::FOAF::Person;
 use strict;
+use warnings;
 
 use RDF::Core::Resource;
 

--- a/t/00-compile.t
+++ b/t/00-compile.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings; 
+
 use Test::More tests => 1;
 
 use_ok 'XML::FOAF';

--- a/t/01-new.t
+++ b/t/01-new.t
@@ -1,4 +1,5 @@
 use strict;
+use warnings; 
 
 use Test::More tests => 7;
 use XML::FOAF;

--- a/t/02-parse.t
+++ b/t/02-parse.t
@@ -1,4 +1,5 @@
 use strict;
+use warnings; 
 
 use Test::More;
 use XML::FOAF;

--- a/t/03-person.t
+++ b/t/03-person.t
@@ -1,4 +1,5 @@
 use strict;
+use warnings; 
 
 use Test::More tests => 15;
 use XML::FOAF;

--- a/t/04-external-entity.t
+++ b/t/04-external-entity.t
@@ -1,4 +1,5 @@
 use strict;
+use warnings; 
 
 use Test::More tests => 2;
 use XML::FOAF;


### PR DESCRIPTION
The [kwalitee report](http://cpants.cpanauthors.org/dist/XML-FOAF) for this dist mentions that warnings are not enabled, this patch enables them.
